### PR TITLE
Pin shared workflow refs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build-and-dispatch:
-    uses: zavestudios/platform-pipelines/.github/workflows/container-build-dispatch.yml@main
+    uses: zavestudios/platform-pipelines/.github/workflows/container-build-dispatch.yml@c0aa80bb405fa24ede5ebcf1c40b0be90328386c
     with:
       image_name: zavestudios/oracle
       dockerfile: Dockerfile

--- a/.github/workflows/workflow-validation.yml
+++ b/.github/workflows/workflow-validation.yml
@@ -20,4 +20,4 @@ permissions:
 jobs:
   validate-workflows:
     name: Validate GitHub Actions Workflows
-    uses: zavestudios/platform-pipelines/.github/workflows/workflow-ci.yml@1a17b8c97621a09b71d50f5493638df902468c9e
+    uses: zavestudios/platform-pipelines/.github/workflows/workflow-ci.yml@0be73c38bcf2e02dc220a2969d4619b4d49d446a

--- a/.github/workflows/workflow-validation.yml
+++ b/.github/workflows/workflow-validation.yml
@@ -20,4 +20,4 @@ permissions:
 jobs:
   validate-workflows:
     name: Validate GitHub Actions Workflows
-    uses: zavestudios/platform-pipelines/.github/workflows/workflow-ci.yml@0be73c38bcf2e02dc220a2969d4619b4d49d446a
+    uses: zavestudios/platform-pipelines/.github/workflows/workflow-ci.yml@a05c4ffcb25a40f874c92b9d17187be031e84eaf

--- a/.github/workflows/workflow-validation.yml
+++ b/.github/workflows/workflow-validation.yml
@@ -11,6 +11,12 @@ on:
       - ".github/workflows/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read
+  packages: write
+  id-token: write
+
 jobs:
   validate-workflows:
     name: Validate GitHub Actions Workflows

--- a/.github/workflows/workflow-validation.yml
+++ b/.github/workflows/workflow-validation.yml
@@ -1,0 +1,17 @@
+name: Workflow Validation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+  workflow_dispatch:
+
+jobs:
+  validate-workflows:
+    name: Validate GitHub Actions Workflows
+    uses: zavestudios/platform-pipelines/.github/workflows/workflow-ci.yml@1a17b8c97621a09b71d50f5493638df902468c9e


### PR DESCRIPTION
## Summary
- replace the floating `platform-pipelines` workflow ref with an immutable commit SHA in the build workflow

## Testing
- workflow reference change only; GitHub Actions validation will run on the PR

## Notes
- pins shared workflow refs to `c0aa80bb405fa24ede5ebcf1c40b0be90328386c`